### PR TITLE
AB#207

### DIFF
--- a/routes/subsidymeasures-add.js
+++ b/routes/subsidymeasures-add.js
@@ -92,7 +92,7 @@ router.get("/", (req, res) => {
     formatedCurrency = "";
     isCallfromEditAward = false;
     var isAddSubsidyPrimarycall = true;
-    ssn.Has_No_End_Date = "";
+    ssn.Has_No_End_Date_Global = false;
 
     if (ssn.dashboard_roles !== "Granting Authority Encoder") {
       res.render("bulkupload/subsidymeasures-add", { isAddSubsidyPrimarycall });


### PR DESCRIPTION
fix(subsidymeasures-add.js): set no end date global to false to stop it from checking box when creating a scheme