### PR TITLE
AB#222 fix: update url and description help text

### DIFF
--- a/views/bulkupload/internalguidancedocument.ejs
+++ b/views/bulkupload/internalguidancedocument.ejs
@@ -85,16 +85,12 @@
                         short summary of the policy or economic background of the scheme.
                     </p>
                     <h4 class="govuk-heading-s">Public authority policy URL</h4>
-                    <p class="govuk-body">You must provide a URL for the webpage that contains the policy that this
-                        subsidy scheme relates to. For example, if you are adding a subsidy scheme that relates to
-                        water
-                        purity, you should provide the URL for the water purity policy.
+                    <p class="govuk-body">This is optional unless you provide a policy page description. You can provide a URL for the webpage that contains the policy that this
+                        subsidy scheme relates to. For example, if you are adding a subsidy scheme that relates to water purity, you should provide the URL for the water purity policy.
                     </p>
                     <h4 class="govuk-heading-s">Public authority policy page description</h4>
-                    <p class="govuk-body">You must provide a short summary of the page that you have entered the URL
-                        for. This will make it easier for other users to understand the contents of the page,
-                        without
-                        clicking on it.
+                    <p class="govuk-body">This is optional unless you provide a policy url. You can provide a short summary of the page that you have entered the URL
+                        for. This will make it easier for other users to understand the contents of the page, without clicking on it.
                     </p>
                     <h4 class="govuk-heading-s">Budget</h4>
                     <p class="govuk-body">You must enter the budget for the subsidy scheme.


### PR DESCRIPTION
ensure that url and description help text no longer state that it's mandatory