### PR TITLE
fix: fix error 500 when adding award

### DIFF
--- a/routes/reviewdetail.js
+++ b/routes/reviewdetail.js
@@ -654,14 +654,12 @@ router.post("/", async (req, res) => {
         } catch (err) {
           if (err.toString().includes("404")) {
             ssn.Subsidy_Control_Number_Error = true;
+            schemeError = true;
             ssn.SubsidyErrors[Additem] =
               "Either subsidy control number (Or) subsidy scheme name is not valid";
             ssn.SubsidyFocus[Additem] = "#Subsidy_Control_Number";
             Additem = Additem + 1;
             ssn.SubsidyArraySize = 1;
-            res.render("bulkupload/addsubsidyaward", {
-              ssn,
-            });
           }
           console.log("error in scheme", err);
         }


### PR DESCRIPTION
set schemeError when no scheme results are found. Also remove extra render causing error 500

[AB#298](https://dev.azure.com/UKGovernmentBEIS/36d85d65-c67d-4e9e-a584-becba0af9291/_workitems/edit/298)