### PR TITLE
AB#236 fix: Changed award full amount input to numerical only

### DIFF
--- a/views/bulkupload/addsubsidyaward.ejs
+++ b/views/bulkupload/addsubsidyaward.ejs
@@ -1147,7 +1147,7 @@
                 <div class="govuk-input__wrapper">
                   <div class="govuk-input__prefix" aria-hidden="true">£</div>
                   <input class="govuk-input govuk-input--width-20 govuk-input--error" id="Subsidy_Element_Full_Amount"
-                    name="Subsidy_Element_Full_Amount" type="text" aria-describedby="Subsidy_Element_Full_Amount"
+                    name="Subsidy_Element_Full_Amount" type="number" inputmode="numeric" min="0" step="0.01" aria-describedby="Subsidy_Element_Full_Amount"
                     <% if(ssn.Subsidy_Element_Full_Amount_Global) {%>
                     value="<%= ssn.Subsidy_Element_Full_Amount_Global%>" <% } %> />
                 </div>
@@ -1166,7 +1166,7 @@
                 <div class="govuk-input__wrapper">
                   <div class="govuk-input__prefix" aria-hidden="true">£</div>
                   <input class="govuk-input govuk-input--width-20 govuk-input--error" id="Subsidy_Element_Full_Amount"
-                    name="Subsidy_Element_Full_Amount" type="text" aria-describedby="Subsidy_Element_Full_Amount"
+                    name="Subsidy_Element_Full_Amount" type="number" inputmode="numeric" min="0" step="0.01" aria-describedby="Subsidy_Element_Full_Amount"
                     <% if(ssn.Subsidy_Element_Full_Amount_Global) {%>
                     value="<%= ssn.Subsidy_Element_Full_Amount_Global%>" <% } %> />
 
@@ -1183,7 +1183,7 @@
                 <div class="govuk-input__wrapper">
                   <div class="govuk-input__prefix" aria-hidden="true">£</div>
                   <input class="govuk-input govuk-input--width-20" id="Subsidy_Element_Full_Amount"
-                    name="Subsidy_Element_Full_Amount" type="text" aria-describedby="Subsidy_Element_Full_Amount"
+                    name="Subsidy_Element_Full_Amount" type="number" inputmode="numeric" min="0" step="0.01" aria-describedby="Subsidy_Element_Full_Amount"
                     <% if(ssn.Subsidy_Element_Full_Amount_Global) {%>
                     value="<%= ssn.Subsidy_Element_Full_Amount_Global%>" <% } %> />
 


### PR DESCRIPTION
Stopped allowing special characters (except '.') in the full amount for subsidy awards to avoid '£' service unavailable.