### PR TITLE
AB#393 - Protect GA roles

### DIFF
--- a/app.js
+++ b/app.js
@@ -410,6 +410,11 @@ app.get("/", async (req, res) => {
   // Globale declarations
   // *******************
   ssn.frontend_totalRecordsPerPage = 10;
+  ssn.protected_gas = ["Granting Authority Encoder", 
+  "Granting Authority Approver", 
+  "Granting Authority Administrator",
+  "BEIS Administrator",
+  "TEST GA"];
 
   var id_token_decoded = jwt_decode(id_token);
   // console.log("id_token_decoded " + id_token_decoded);

--- a/routes/grantingauthority-deactivate.js
+++ b/routes/grantingauthority-deactivate.js
@@ -68,9 +68,11 @@ router.get("/", async (req, res) => {
       } catch (err) {
         if (err.toString().includes("500"))
           res.render("bulkupload/notAvailable");
+        else if(err.toString().includes("403"))
+          res.render("bulkupload/notAuthorized");
         console.log("message error deactivate GA : " + err);
         // res.render("publicusersearch/noresults");
-      }
+      } 
     } catch (err) {
       if (err.toString().includes("500")) res.render("bulkupload/notAvailable");
       console.log("Error while fetching GA user List", err);

--- a/routes/grantingauthority-deactivate.js
+++ b/routes/grantingauthority-deactivate.js
@@ -72,7 +72,7 @@ router.get("/", async (req, res) => {
           res.render("bulkupload/notAuthorized");
         console.log("message error deactivate GA : " + err);
         // res.render("publicusersearch/noresults");
-      } 
+      }
     } catch (err) {
       if (err.toString().includes("500")) res.render("bulkupload/notAvailable");
       console.log("Error while fetching GA user List", err);

--- a/routes/grantingauthority-editreview.js
+++ b/routes/grantingauthority-editreview.js
@@ -53,7 +53,9 @@ router.get("/", async (req, res) => {
         res.render("bulkupload/notAuthorized");
       }
     } catch (err) {
-      if (err.toString().includes("500")) res.render("bulkupload/notAvailable");
+      if (err.toString().includes("500") || err.toString().includes("404"))
+        res.render("bulkupload/notAvailable");
+      
       console.log("message error deactivate GA : " + err);
       // res.render("publicusersearch/noresults");
     }

--- a/routes/grantingauthority-editreview.js
+++ b/routes/grantingauthority-editreview.js
@@ -41,6 +41,7 @@ router.get("/", async (req, res) => {
       ssn.gaName = apidata.data.gaList[0].grantingAuthorityName;
       ssn.grantingAuthorityPublish_Global = false;
       ssn.GAstatus = apidata.data.gaList[0].status;
+      ssn.protectedGA = ssn.protected_gas.includes(ssn.gaName);
       if (ssn.dashboard_roles == "BEIS Administrator") {
         res.render("bulkupload/grantingauthority-editreview", {
           // ssn.grantingAuthorityID_Global,

--- a/views/bulkupload/grantingauthority-editreview.ejs
+++ b/views/bulkupload/grantingauthority-editreview.ejs
@@ -112,7 +112,7 @@
             <a class="govuk-button" href="/mygrantingauthority" data-module="govuk-button">
                 Back to public authority list
             </a>
-            <% if(ssn.GAstatus == 'Active') { %>
+            <% if(ssn.GAstatus == 'Active' && !ssn.protectedGA) { %>
             <a class="govuk-button govuk-button--warning" href="/deactivategrantingauthority"
                 data-module="govuk-button">
                 Deactivate public authority


### PR DESCRIPTION
Removed "Deactivate Granting Authority" button when GA name is a part of the list defined in app.js

These GAs are:

- "Granting Authority Encoder"
- "Granting Authority Approver"
- "Granting Authority Administrator"
- "BEIS Administrator"
- "TEST GA"