### PR TITLE
Ab#463 authority url visibility

### DIFF
--- a/views/bulkupload/reviewdetail.ejs
+++ b/views/bulkupload/reviewdetail.ejs
@@ -200,7 +200,7 @@
             Public authority policy URL
           </dt>
           <dd class="govuk-summary-list__value">
-            <%= ssn.Authority_URL_Global %>
+            <%= (ssn.Standalone_Award_Global === 'No') ? 'NA' : ssn.Authority_URL_Global %>
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -208,7 +208,7 @@
             Public authority policy page summary
           </dt>
           <dd class="govuk-summary-list__value">
-            <%= ssn.Authority_URL_Description_Global %>
+            <%= (ssn.Standalone_Award_Global === 'No') ? 'NA' : ssn.Authority_URL_Description_Global %>
           </dd>
         </div>
 

--- a/views/bulkupload/subsidyaward-fetch.ejs
+++ b/views/bulkupload/subsidyaward-fetch.ejs
@@ -234,34 +234,30 @@
                         </dd>
                     </div>
                     
-                    <%if(fetchawarddetails.standaloneAward === "Yes") { %>
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
                             Public authority policy URL
                         </dt>
                         <dd class="govuk-summary-list__value">
                         <% if(typeof fetchawarddetails.authorityURL != 'undefined') { %>
-                            <% if(fetchawarddetails.authorityURL.includes('https://')) { %>
                                 <a aria-label="Weblink to public authority" target="_blank"
-                                  href="<%= fetchawarddetails.authorityURL %>">
-                                  <%= fetchawarddetails.authorityURL %>
-                              <% } else { %>
-                                <a aria-label="Weblink to public authority" target="_blank"
-                                  href="https://<%= fetchawarddetails.authorityURL %>">
-                                  <%= fetchawarddetails.authorityURL %>
+                                  href="<%= (fetchawarddetails.authorityURL.includes('https://')) ?  fetchawarddetails.authorityURL 
+                                  : 'https://'+fetchawarddetails.authorityURL %>">
+                                  <%=fetchawarddetails.authorityURL %>
                                 </a>
-                        <% }} %>
+                        <% } else { %>
+                            <a aria-label="Public authority policy URL not applicable" >NA</a>
                         </dd>
+                        <%  } %>
                     </div>
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
                             Public authority policy page summary
                         </dt>
                         <dd class="govuk-summary-list__value">
-                            <%= fetchawarddetails.authorityURLDescription  %>
+                            <%= (fetchawarddetails.standaloneAward === 'No') ? 'NA' : fetchawarddetails.authorityURLDescription %>
                         </dd>
                     </div>
-                    <% } %>
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
                             Award date


### PR DESCRIPTION
fix: Rewrote conditionals on pages that refer to public authority url and its description

NA shown when authority url is not applicable (previously was hidden)